### PR TITLE
fix: add minimum version for cryptography library

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -26,8 +26,6 @@ exclude = [
     "node_modules",
     "site-packages",
     "venv",
-    "bls/*",
-    "pactus/__init__.py",
 ]
 
 # Same as Black.

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ LONG_DESCRIPTION_CONTENT_TYPE = "text/markdown"
 URL = "https://github.com/pactus-project/python-sdk"
 
 # Package dependencies
-REQUIRED = ["ripemd-hash", "grpcio", "grpcio-tools", "cryptography"]
+REQUIRED = ["ripemd-hash", "grpcio", "grpcio-tools", "cryptography>=43.0"]
 
 CLASSIFIERS = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
This PR specifies the minimum version for the `cryptography` library.