### PR TITLE
chore: bump version to 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ ruff check # running linter
 
 Contributions are welcome! Feel free to add features, fix bugs, or improve documentation via pull requests.
 
+## Publishing to PyPi
+
+To deploy `pactus-sdk` and create a release, tag the new version and push it to GitHub.
+
+```bash
+git tag -s -a v1.x.y -m "Version 1.x.y"
+```
+
+After publishing, make sure to update the version number in `setup.py`.
+
 ## License
 
 This project is licensed under the [MIT License](./LICENSE).

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with codecs.open(here / "README.md", encoding="utf-8") as fh:
     long_description = fh.read()
 
 NAME = "pactus-sdk"
-VERSION = "1.1.0"
+VERSION = "1.2.0"
 AUTHOR = "Pactus Development Team"
 AUTHOR_EMAIL = "info@pactus.org"
 DESCRIPTION = "Pactus Development Kit"


### PR DESCRIPTION
This PR bumps the version to `v1.2.0` and updates the README to include instructions for publishing to PyPi.