### PR TITLE
fix: correct conversion method for Amount class

### DIFF
--- a/pactus/types/amount.py
+++ b/pactus/types/amount.py
@@ -3,17 +3,17 @@ import math
 NANO_PAC_PER_PAC = 1e9
 MAX_NANO_PAC = 42e6 * NANO_PAC_PER_PAC
 
-
 class Amount:
     """
-    The Amount class represents a quantity in NanoPAC.
+    Amount represents the atomic unit in the Pactus blockchain.
+    Each unit is equal to 1e-9 of a PAC.
 
-    The `from_NanoPAC` method creates an Amount from a floating-point value
+    The `from_pac` method creates an Amount from a floating-point value
     representing an amount in PAC. It raises an error if the value is NaN or
-    +-Infinity, but it does not check whether the amount exceeds the total
+    ±Infinity, but it does not check whether the amount exceeds the total
     amount of PAC producible. This method is specifically for converting PAC
-    to NanoPAC. For creating a new Amount with an integer value representing
-    NanoPAC, you can initialize the Amount directly with an integer.
+    to NanoPAC. To create a new Amount with an integer value representing
+    NanoPAC, you can use the `from_nano_pac` method.
     """
 
     def __init__(self, amt: int = 0) -> None:
@@ -26,11 +26,16 @@ class Amount:
         return False
 
     @classmethod
-    def from_nano_pac(cls, f: float) -> "Amount":
-        """
-        Convert a floating-point value in PAC to NanoPAC and stores it in the Amount instance.
+    def from_nano_pac(cls, a: int) -> "Amount":
+        """Store the value as NanoPAC in the Amount instance."""
+        return cls(a)
 
-        The conversion is invalid if the floating-point value is NaN or +-Infinity,
+    @classmethod
+    def from_pac(cls, f: float) -> "Amount":
+        """
+        Convert a floating-point value in PAC to NanoPAC and store it in the Amount instance.
+
+        The conversion is invalid if the floating-point value is NaN or ±Infinity,
         in which case a ValueError is raised.
         """
         if math.isinf(f) or math.isnan(f):
@@ -53,7 +58,7 @@ class Amount:
             msg = "invalid PAC amount"
             raise ValueError(msg) from e
 
-        return cls.from_nano_pac(f)
+        return cls.from_pac(f)
 
     def round(self: float) -> float:
         """

--- a/pactus/types/amount.py
+++ b/pactus/types/amount.py
@@ -42,7 +42,7 @@ class Amount:
             msg = f"invalid PAC amount: {f}"
             raise ValueError(msg)
 
-        return cls(int(cls.round(f * NANO_PAC_PER_PAC)))
+        return cls.from_nano_pac(int(cls.round(f * NANO_PAC_PER_PAC)))
 
     @classmethod
     def from_string(cls, s: str) -> "Amount":

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with codecs.open(here / "README.md", encoding="utf-8") as fh:
     long_description = fh.read()
 
 NAME = "pactus-sdk"
-VERSION = "1.2.0"
+VERSION = "1.1.1"
 AUTHOR = "Pactus Development Team"
 AUTHOR_EMAIL = "info@pactus.org"
 DESCRIPTION = "Pactus Development Kit"

--- a/tests/test_amount.py
+++ b/tests/test_amount.py
@@ -4,7 +4,7 @@ from pactus.types.amount import NANO_PAC_PER_PAC, Amount
 
 
 class TestAmount(unittest.TestCase):
-    def test_from_nano_pac(self):
+    def test_from_pac(self):
         test_cases = [
             # Valid cases
             {
@@ -27,9 +27,9 @@ class TestAmount(unittest.TestCase):
         for case in test_cases:
             if case["raises"]:
                 with self.assertRaises(case["raises"]):
-                    Amount.from_nano_pac(case["input"])
+                    Amount.from_pac(case["input"])
             else:
-                amt = Amount.from_nano_pac(case["input"])
+                amt = Amount.from_pac(case["input"])
                 self.assertEqual(amt, case["expected"])
 
     def test_from_string(self):

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -12,8 +12,8 @@ class TestTransaction(unittest.TestCase):
         prv = PrivateKey.from_string(prv_str)
         sender = Address.from_string("pc1z5x2a0lkt5nrrdqe0rkcv6r4pfkmdhrr3mawvua")
         receiver = Address.from_string("pc1zt6qcdymkk48c5ds0fzfsaf6puwu8w8djn3ffpn")
-        amount = Amount.from_nano_pac(1.0)  # 1 PAC
-        fee = Amount.from_nano_pac(0.001)  # 0.001 PAC
+        amount = Amount.from_pac(1.0)  # 1 PAC
+        fee = Amount.from_pac(0.001)  # 0.001 PAC
         lock_time = 0x123456
         memo = "test"
 


### PR DESCRIPTION
This PR addresses an issue where the `from_nano_pac` method was incorrectly used to convert PAC to `Amount`.
 Instead, the appropriate method, `from_pac`, should be utilized for this conversion. This 