### PR TITLE
feat: make Block.id and Transaction.id() return Hash instead of bytes

### DIFF
--- a/pactus/block/block.py
+++ b/pactus/block/block.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import struct
 
+from pactus.crypto.hash import Hash
 from pactus.encoding import encoding
 from pactus.transaction import Transaction
 
@@ -43,20 +44,20 @@ class Block:
         return cls(header, prev_cert, transactions)
 
     @property
-    def id(self) -> bytes:
+    def id(self) -> Hash:
         """Return the block ID (blake2b-256 of header + cert_hash + tx_root + tx_count)."""
         buf = self._header_bytes()
         if self.prev_cert is not None:
             buf += self.prev_cert.hash()
         buf += self._txs_root()
         buf += struct.pack("<i", len(self.transactions))
-        return hashlib.blake2b(buf, digest_size=32).digest()
+        return Hash(hashlib.blake2b(buf, digest_size=32).digest())
 
     def _header_bytes(self) -> bytes:
         return self.header.encode(b"")
 
     def _txs_root(self) -> bytes:
-        return Block._merkle_root([tx.id() for tx in self.transactions])
+        return Block._merkle_root([tx.id().data for tx in self.transactions])
 
     @staticmethod
     def _merkle_root(hashes: list) -> bytes:

--- a/pactus/transaction/transaction.py
+++ b/pactus/transaction/transaction.py
@@ -7,6 +7,7 @@ from pactus.crypto.bls.public_key import PublicKey as BLSPublicKey
 from pactus.crypto.bls.signature import Signature as BLSSignature
 from pactus.crypto.ed25519.public_key import PublicKey as Ed25519PublicKey
 from pactus.crypto.ed25519.signature import Signature as Ed25519Signature
+from pactus.crypto.hash import Hash
 from pactus.crypto.private_key import PrivateKey
 from pactus.crypto.public_key import PublicKey
 from pactus.crypto.secp256k1.public_key import PublicKey as Secp256k1PublicKey
@@ -184,9 +185,9 @@ class Transaction:
         buf = self._get_unsigned_bytes(b"")
         return buf[1:]
 
-    def id(self) -> bytes:
+    def id(self) -> Hash:
         """Return the transaction ID (blake2b-256 of sign bytes)."""
-        return hashlib.blake2b(self.sign_bytes(), digest_size=32).digest()
+        return Hash(hashlib.blake2b(self.sign_bytes(), digest_size=32).digest())
 
     def sign(self, private_key: PrivateKey) -> bytes:
         """Sign the transaction and return signed bytes."""

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -68,7 +68,7 @@ class TestBlockDecode(unittest.TestCase):
 
         # --- Block ID ---
         self.assertEqual(
-            block.id.hex(),
+            str(block.id),
             "5a12881b1d5fd9bea3a61f24d7555d8900e85d02e9606b5a3176edf3c355a32d",
         )
 


### PR DESCRIPTION
## Summary

Previously, `Block.id` (property) and `Transaction.id()` both returned raw `bytes`. This PR wraps the computed blake2b-256 hash in a `Hash` object, providing type safety and a consistent interface across the SDK.

## Changes

- **`pactus/transaction/transaction.py`**: `id()` now returns `Hash` instead of `bytes`
- **`pactus/block/block.py`**: `id` property now returns `Hash` instead of `bytes`; `_txs_root` extracts `.data` from each `tx.id()` since `_merkle_root` operates on raw bytes
- **`tests/test_block.py`**: updated assertion from `block.id.hex()` to `str(block.id)` to match `Hash.__str__`

## Testing

All 45 tests pass.